### PR TITLE
Detailed logging for decryption/validation

### DIFF
--- a/lib/decrypt_mails.rb
+++ b/lib/decrypt_mails.rb
@@ -11,6 +11,15 @@ module DecryptMails
 
     def receive_with_encryption(email, options={})
 
+      # Extract useful metadata for logging
+      sender_email = email.from.to_a.first.to_s.strip
+      # We need to store this before decryption, because after decryption
+      # email.encrypted? == false
+      encrypted = email.encrypted?
+      # Sometimes this isn't available after decryption. This seems like a bug,
+      # so extract it here so we're guaranteed to have it
+      message_id = email.message_id
+
       # encrypt and check validity of signature
       if email.encrypted?
         email = email.decrypt(
@@ -32,7 +41,6 @@ module DecryptMails
       # compare identity of signature with sender
       if valid
         valid = false
-        sender_email = email.from.to_a.first.to_s.strip
         user = User.find_by_mail sender_email if sender_email.present?
         key = Pgpkey.find_by user_id: user.id
         signatures.each do |s|
@@ -41,10 +49,17 @@ module DecryptMails
       end
 
       # error on invalid signature
-      if Setting.plugin_openpgp['signature_needed'] and not valid
-        if logger
-          logger.info "MailHandler: ignoring emails with invalid signature"
-        end
+      ignored = !!(Setting.plugin_openpgp['signature_needed'] and not valid)
+
+      if logger
+        logger.info "MailHandler: received email from #{sender_email} " +
+                    "with Message-ID #{message_id}: " +
+                    "encrypted=#{encrypted}, " +
+                    "valid=#{valid}, "+
+                    "ignored=#{ignored}"
+      end
+
+      if ignored
         return false
       end
 


### PR DESCRIPTION
Currently, if the server is unable to verify an email, and "Valid signatures only" is enabled, it logs `MailHandler: ignoring emails with invalid signature`. This is helpful because otherwise the message is dropped with no indication to the sender or the Redmine administator.

However, it lacks details that could assist troubleshooting. Ideally, the log message would also include the sender and a unique ID for the message (e.g. `Message-ID`), so an administrator could try to troubleshoot the problem (and potentially recover and examine emails that were rejected from the IMAP server).

Additionally, some servers might like to try to enforce or strongly encourage that all _incoming_ mail is encrypted (in addition to encrypting _outgoing_ mail, which is handled by redmine_openpg). I filed #9 to address this with a comprehensive feature, but as a stop-gap measure it would be helpful for an administrator to be able to determine if their Redmine instance is receiving unencrypted mail.

This pull request:
- Prints a log line for every email received
- Includes the sender address and Message-ID to assist troubleshooting
- Indicates whether the message was encrypted/not encrypted, had a valid/invalid signature, or was ignored/not ignored. This assists troubleshooting and enables some useful monitoring (e.g. detecting when users are sending unencrypted email, and following up with them individually, as a stop-gap until something is implemented for #9).

The new log lines look like this:

```
MailHandler: received email from garrett@freedom.press with Message-ID 56A16AB1.6010707@freedom.press: encrypted=true, valid=true, ignored=false
```
