### PR TITLE
Validate with all signing subkeys

### DIFF
--- a/app/models/pgpkey.rb
+++ b/app/models/pgpkey.rb
@@ -8,4 +8,8 @@ class Pgpkey < ActiveRecord::Base
   def metadata
     GPGME::Key.get(self.fpr).to_s
   end
+
+  def subkeys
+    GPGME::Key.get(self.fpr).subkeys
+  end
 end

--- a/lib/decrypt_mails.rb
+++ b/lib/decrypt_mails.rb
@@ -36,7 +36,10 @@ module DecryptMails
         user = User.find_by_mail sender_email if sender_email.present?
         key = Pgpkey.find_by user_id: user.id
         signatures.each do |s|
-          valid = true if key.fpr == s.fpr
+          key.subkeys.each do |subkey|
+            valid = true if subkey.capability.include? :sign and \
+                            subkey.fpr == s.fpr
+          end
         end if not signatures.empty?
       end
 


### PR DESCRIPTION
Fixes #11.

This works, but is unfortunately affected by an issue in `ruby-gpgme` where it incorrectly reports that all subkeys have every capability (I just filed https://github.com/ueno/ruby-gpgme/issues/76 for this). This will _not_ cause any breakage. It just means that until the ruby-gpgme issue is fixed, the identity comparison will compare the fingerprint of the key that generated the signature (`s.fpr`) against _every_ subkey, instead of just the subkeys that have the sign capability, because `ruby-gpgme` currently incorrectly reports that every subkey has every capability.

Since GPG will only generate signatures from signing subkeys, I do not believe this will cause any problems in practice.
